### PR TITLE
Systemd support + pulsar-user

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,14 +17,14 @@ easily be installed via a pre-task in the same play as this role:
 
     - hosts: pulsarservers
         pre_tasks:
-          - name: Install Mercurial
+          - name: Install git
             apt: pkg={{ item }} state=installed
             sudo: yes
             when: ansible_os_family = 'Debian'
             with_items:
               - git
               - python-virtualenv
-          - name: Install Mercurial
+          - name: Install git
             yum: pkg={{ item }} state=installed
             sudo: yes
             when: ansible_os_family = 'RedHat'
@@ -187,9 +187,6 @@ Install Pulsar with directory separation and also install Galaxy:
         galaxy_config_files:
           - name: files/galaxy/config/datatypes_conf.xml
             dest: "{{ galaxy_config_dir }}/datatypes_conf.xml"
-      pre_tasks:
-        - name: Install Mercurial
-          pip: name=mercurial virtualenv={{ hg_virtualenv }} virtualenv_command={{ pip_virtualenv_command | default(omit) }}
       roles:
         - role: galaxyproject.pulsar
         # Install with:
@@ -208,5 +205,5 @@ License
 Author Information
 ------------------
 
-[John Chilton](https://github.com/jmchilton)  
+[John Chilton](https://github.com/jmchilton)
 [Nate Coraor](https://github.com/natefoo)

--- a/README.md
+++ b/README.md
@@ -205,5 +205,6 @@ License
 Author Information
 ------------------
 
-[John Chilton](https://github.com/jmchilton)
-[Nate Coraor](https://github.com/natefoo)
+- [John Chilton](https://github.com/jmchilton)
+- [Nate Coraor](https://github.com/natefoo)
+- [Helena Rasche](https://github.com/erasche)

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -38,3 +38,15 @@ pulsar_optional_dependencies: []
 # OpenSSL, libffi) are not installed system wide on destination, environment
 # variables can be used to target other paths.
 pulsar_install_environments: []
+
+pulsar_owner: root
+pulsar_group: root
+pulsar_user_create: false
+pulsar_user_homedir: "{{ pulsar_config_dir }}"
+
+pulsar_config_filemode: 0444
+pulsar_config_backup: true
+# To deploy a systemd unit file
+# pulsar_systemd: true
+pulsar_systemd_enabled: yes
+pulsar_systemd_state: started

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -39,14 +39,8 @@ pulsar_optional_dependencies: []
 # variables can be used to target other paths.
 pulsar_install_environments: []
 
-pulsar_owner: root
-pulsar_group: root
-pulsar_user_create: false
-pulsar_user_homedir: "{{ pulsar_config_dir }}"
-
-pulsar_config_filemode: 0444
-pulsar_config_backup: true
 # To deploy a systemd unit file
 # pulsar_systemd: true
-pulsar_systemd_enabled: yes
+pulsar_systemd: false
+pulsar_systemd_enabled: true
 pulsar_systemd_state: started

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -52,29 +52,18 @@
   with_items: "{{ pulsar_optional_dependencies }}"
 
 - name: Create Pulsar config dir
-  file:
-    state: directory
-    path: "{{ pulsar_config_dir }}"
+  file: state=directory path={{ pulsar_config_dir }}
 
 - name: Create Pulsar app configuration file
-  template:
-    src: app.yml.j2
-    dest: "{{ pulsar_config_dir }}/app.yml"
-    backup: "{{ pulsar_config_backup }}"
+  template: src=app.yml.j2 dest={{ pulsar_config_dir }}/app.yml mode=0444 backup=yes
   when: pulsar_yaml_config is defined
 
 - name: Create Pulsar job manager configuration file
-  template:
-    src: "job_managers.ini.j2"
-    dest: "{{ pulsar_job_managers_config }}"
-    backup: "{{ pulsar_config_backup }}"
+  template: src=job_managers.ini.j2 dest={{ pulsar_job_managers_config }} mode=0444 backup=yes
   when: pulsar_job_managers is defined
 
 - name: Create additional Pulsar config files
-  template:
-    src: "{{ item }}.j2"
-    dest: "{{ pulsar_config_dir }}/{{ item }}"
-    backup: "{{ pulsar_config_backup }}"
+  template: src={{ item }}.j2 dest={{ pulsar_config_dir }}/{{ item }} mode=0444 backup=yes
   with_items:
     - server.ini
     - local_env.sh

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,12 +4,39 @@
 # Deploy a Pulsar server
 #   http://pulsar.readthedocs.org/
 
+- name: Create user if requested
+  user:
+    name: "{{ pulsar_owner }}"
+    create_home: no
+    append: yes
+    system: yes
+    home: "{{ pulsar_user_homedir }}"
+  when: pulsar_user_create
+
+- name: Ensure pip and virtualenv commands are available
+  package:
+    name: "{{ item }}"
+    state: installed
+  with_items:
+    - python-pip
+    - python-virtualenv
+
+- name: Create virtualenv dir
+  file:
+    state: directory
+    path: "{{ pulsar_venv_dir }}"
+    mode: 0755
+    owner: "{{ pulsar_owner }}"
+    group: "{{ pulsar_group }}"
+
 - name: Create/update virtualenv
   pip:
     name: "{{ item }}"
     state: latest
     virtualenv: "{{ pulsar_venv_dir }}"
     virtualenv_command: "{{ pip_virtualenv_command | default(omit) }}"
+  become: true
+  become_user: "{{ pulsar_owner }}"
   with_items:
     - pip
     - setuptools
@@ -21,6 +48,8 @@
     virtualenv: "{{ pulsar_venv_dir }}"
     editable: false
     state: forcereinstall
+  become: true
+  become_user: "{{ pulsar_owner }}"
   when: pulsar_pip_install == true and pulsar_changeset_id is defined
 
 - name: Install Pulsar (pip)
@@ -28,35 +57,92 @@
     name: pulsar-app
     state: latest
     virtualenv: "{{ pulsar_venv_dir }}"
+  become: true
+  become_user: "{{ pulsar_owner }}"
   when: pulsar_pip_install == true and pulsar_changeset_id is not defined
+
+- name: Create server directory
+  file:
+    state: directory
+    path: "{{ pulsar_server_dir }}"
+    mode: 0755
+    owner: "{{ pulsar_owner }}"
+    group: "{{ pulsar_group }}"
+  when: pulsar_pip_install == false
 
 - name: Install Pulsar (source)
   git: dest={{ pulsar_server_dir }} force=no repo={{ pulsar_git_repo }} version={{ pulsar_changeset_id | default('master') }} executable={{ git_executable | default(omit) }}
+  become: true
+  become_user: "{{ pulsar_owner }}"
   when: pulsar_pip_install == false
 
 - name: Install Pulsar base dependencies for source install
   pip: requirements={{ pulsar_server_dir }}/requirements.txt virtualenv={{ pulsar_venv_dir }} virtualenv_command={{ pip_virtualenv_command | default(omit) }}
+  become: true
+  become_user: "{{ pulsar_owner }}"
   when: pulsar_pip_install == false
 
 - name: Install Pulsar dependencies (optional)
   pip: name={{ item }} virtualenv={{ pulsar_venv_dir }} virtualenv_command={{ pip_virtualenv_command | default(omit) }}
   environment: "{{ pulsar_install_environments[item.split('=')[0]] if item.split('=')[0] in pulsar_install_environments else {} }}"
+  become: true
+  become_user: "{{ pulsar_owner }}"
   with_items: "{{ pulsar_optional_dependencies }}"
 
 - name: Create Pulsar config dir
-  file: state=directory path={{ pulsar_config_dir }}
+  file:
+    state: directory
+    path: "{{ pulsar_config_dir }}"
+    mode: 0755
+    owner: "{{ pulsar_owner }}"
+    group: "{{ pulsar_group }}"
 
 - name: Create Pulsar app configuration file
-  template: src=app.yml.j2 dest={{ pulsar_config_dir }}/app.yml mode=0444 backup=yes
+  template:
+    src: app.yml.j2
+    dest: "{{ pulsar_config_dir }}/app.yml"
+    mode: "{{ pulsar_config_filemode }}"
+    owner: "{{ pulsar_owner }}"
+    group: "{{ pulsar_group }}"
+    backup: "{{ pulsar_config_backup }}"
   when: pulsar_yaml_config is defined
 
 - name: Create Pulsar job manager configuration file
-  template: src=job_managers.ini.j2 dest={{ pulsar_job_managers_config }} mode=0444 backup=yes
+  template:
+    src: "job_managers.ini.j2"
+    dest: "{{ pulsar_job_managers_config }}"
+    mode: "{{ pulsar_config_filemode }}"
+    owner: "{{ pulsar_owner }}"
+    group: "{{ pulsar_group }}"
+    backup: "{{ pulsar_config_backup }}"
   when: pulsar_job_managers is defined
 
 - name: Create additional Pulsar config files
-  template: src={{ item }}.j2 dest={{ pulsar_config_dir }}/{{ item }} mode=0444 backup=yes
+  template:
+    src: "{{ item }}.j2"
+    dest: "{{ pulsar_config_dir }}/{{ item }}"
+    mode: "{{ pulsar_config_filemode }}"
+    owner: "{{ pulsar_owner }}"
+    group: "{{ pulsar_group }}"
+    backup: "{{ pulsar_config_backup }}"
   with_items:
     - server.ini
     - local_env.sh
     - job_metrics_conf.xml
+
+- name: Create Pulsar systemd unit file
+  template:
+    src: "pulsar.service.j2"
+    dest: "/etc/systemd/system/pulsar.service"
+    mode: "0640"
+    owner: "root"
+    group: "root"
+  when: pulsar_systemd is defined
+
+- name: SystemD daemon-reload and enable/start service
+  systemd:
+    state: "{{ pulsar_systemd_state }}"
+    enabled: "{{ pulsar_systemd_enabled }}"
+    name: pulsar.service
+    daemon_reload: yes
+  when: pulsar_systemd is defined

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,15 +4,6 @@
 # Deploy a Pulsar server
 #   http://pulsar.readthedocs.org/
 
-- name: Create user if requested
-  user:
-    name: "{{ pulsar_owner }}"
-    create_home: no
-    append: yes
-    system: yes
-    home: "{{ pulsar_user_homedir }}"
-  when: pulsar_user_create
-
 - name: Ensure pip and virtualenv commands are available
   package:
     name: "{{ item }}"
@@ -21,22 +12,12 @@
     - python-pip
     - python-virtualenv
 
-- name: Create virtualenv dir
-  file:
-    state: directory
-    path: "{{ pulsar_venv_dir }}"
-    mode: 0755
-    owner: "{{ pulsar_owner }}"
-    group: "{{ pulsar_group }}"
-
 - name: Create/update virtualenv
   pip:
     name: "{{ item }}"
     state: latest
     virtualenv: "{{ pulsar_venv_dir }}"
     virtualenv_command: "{{ pip_virtualenv_command | default(omit) }}"
-  become: true
-  become_user: "{{ pulsar_owner }}"
   with_items:
     - pip
     - setuptools
@@ -48,8 +29,6 @@
     virtualenv: "{{ pulsar_venv_dir }}"
     editable: false
     state: forcereinstall
-  become: true
-  become_user: "{{ pulsar_owner }}"
   when: pulsar_pip_install == true and pulsar_changeset_id is defined
 
 - name: Install Pulsar (pip)
@@ -57,53 +36,30 @@
     name: pulsar-app
     state: latest
     virtualenv: "{{ pulsar_venv_dir }}"
-  become: true
-  become_user: "{{ pulsar_owner }}"
   when: pulsar_pip_install == true and pulsar_changeset_id is not defined
-
-- name: Create server directory
-  file:
-    state: directory
-    path: "{{ pulsar_server_dir }}"
-    mode: 0755
-    owner: "{{ pulsar_owner }}"
-    group: "{{ pulsar_group }}"
-  when: pulsar_pip_install == false
 
 - name: Install Pulsar (source)
   git: dest={{ pulsar_server_dir }} force=no repo={{ pulsar_git_repo }} version={{ pulsar_changeset_id | default('master') }} executable={{ git_executable | default(omit) }}
-  become: true
-  become_user: "{{ pulsar_owner }}"
   when: pulsar_pip_install == false
 
 - name: Install Pulsar base dependencies for source install
   pip: requirements={{ pulsar_server_dir }}/requirements.txt virtualenv={{ pulsar_venv_dir }} virtualenv_command={{ pip_virtualenv_command | default(omit) }}
-  become: true
-  become_user: "{{ pulsar_owner }}"
   when: pulsar_pip_install == false
 
 - name: Install Pulsar dependencies (optional)
   pip: name={{ item }} virtualenv={{ pulsar_venv_dir }} virtualenv_command={{ pip_virtualenv_command | default(omit) }}
   environment: "{{ pulsar_install_environments[item.split('=')[0]] if item.split('=')[0] in pulsar_install_environments else {} }}"
-  become: true
-  become_user: "{{ pulsar_owner }}"
   with_items: "{{ pulsar_optional_dependencies }}"
 
 - name: Create Pulsar config dir
   file:
     state: directory
     path: "{{ pulsar_config_dir }}"
-    mode: 0755
-    owner: "{{ pulsar_owner }}"
-    group: "{{ pulsar_group }}"
 
 - name: Create Pulsar app configuration file
   template:
     src: app.yml.j2
     dest: "{{ pulsar_config_dir }}/app.yml"
-    mode: "{{ pulsar_config_filemode }}"
-    owner: "{{ pulsar_owner }}"
-    group: "{{ pulsar_group }}"
     backup: "{{ pulsar_config_backup }}"
   when: pulsar_yaml_config is defined
 
@@ -111,9 +67,6 @@
   template:
     src: "job_managers.ini.j2"
     dest: "{{ pulsar_job_managers_config }}"
-    mode: "{{ pulsar_config_filemode }}"
-    owner: "{{ pulsar_owner }}"
-    group: "{{ pulsar_group }}"
     backup: "{{ pulsar_config_backup }}"
   when: pulsar_job_managers is defined
 
@@ -121,28 +74,11 @@
   template:
     src: "{{ item }}.j2"
     dest: "{{ pulsar_config_dir }}/{{ item }}"
-    mode: "{{ pulsar_config_filemode }}"
-    owner: "{{ pulsar_owner }}"
-    group: "{{ pulsar_group }}"
     backup: "{{ pulsar_config_backup }}"
   with_items:
     - server.ini
     - local_env.sh
     - job_metrics_conf.xml
 
-- name: Create Pulsar systemd unit file
-  template:
-    src: "pulsar.service.j2"
-    dest: "/etc/systemd/system/pulsar.service"
-    mode: "0640"
-    owner: "root"
-    group: "root"
-  when: pulsar_systemd is defined
-
-- name: SystemD daemon-reload and enable/start service
-  systemd:
-    state: "{{ pulsar_systemd_state }}"
-    enabled: "{{ pulsar_systemd_enabled }}"
-    name: pulsar.service
-    daemon_reload: yes
-  when: pulsar_systemd is defined
+- include_tasks: systemd.yml
+  when: pulsar_systemd

--- a/tasks/systemd.yml
+++ b/tasks/systemd.yml
@@ -1,0 +1,12 @@
+---
+- name: Create Pulsar systemd unit file
+  template:
+    src: "pulsar.service.j2"
+    dest: "/etc/systemd/system/pulsar.service"
+
+- name: SystemD daemon-reload and enable/start service
+  systemd:
+    state: "{{ pulsar_systemd_state }}"
+    enabled: "{{ pulsar_systemd_enabled }}"
+    name: pulsar.service
+    daemon_reload: yes

--- a/templates/pulsar.service.j2
+++ b/templates/pulsar.service.j2
@@ -1,0 +1,11 @@
+[Unit]
+Description=Pulsar
+After=syslog.target network.target
+
+[Service]
+Type=simple
+ExecStart={{ pulsar_venv_dir }}/bin/python {{ pulsar_venv_dir }}/bin/paster serve {{ pulsar_config_dir }}/server.ini
+User={{ pulsar_owner }}
+
+[Install]
+WantedBy=multi-user.target

--- a/templates/pulsar.service.j2
+++ b/templates/pulsar.service.j2
@@ -5,7 +5,6 @@ After=syslog.target network.target
 [Service]
 Type=simple
 ExecStart={{ pulsar_venv_dir }}/bin/python {{ pulsar_venv_dir }}/bin/paster serve {{ pulsar_config_dir }}/server.ini
-User={{ pulsar_owner }}
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
- ensure python-pip/python-virtualenv are installed
- provides a systemd unit that can be loaded on demand (I'm not writing a sysv init script so it's systemd or nothing and I've used the systemd module instead of the more generic service module.) (SystemD unit only supports paste server. Have not tested with uWSGI.)
- Handles creation of a special `pulsar` user (if desired.) Defaults to root.
- Allows changing filemode from 0444
- Allows disabling file backup