### PR TITLE
py3k

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ the `pip_virtualenv_command` variable.
 Breaking Changes
 ----------------
 
-As of 1.0.0, installation with git+pip, and from source, are no longer supported.
+As of 1.0.0, installation directly from source using `git clone` is no longer supported. However, `pulsar_package_name` and `pulsar_package_version` can be used to install using pip's `git+https` method.
 
 Role Variables
 --------------

--- a/README.md
+++ b/README.md
@@ -17,20 +17,23 @@ easily be installed via a pre-task in the same play as this role:
 
     - hosts: pulsarservers
         pre_tasks:
-          - name: Install git
-            apt: pkg={{ item }} state=installed
-            sudo: yes
+          - name: Install dependencies
+            package:
+              name:
+                - git
+                - virtualenv
+                - python3
+            become: true
             when: ansible_os_family = 'Debian'
-            with_items:
-              - git
-              - python-virtualenv
-          - name: Install git
-            yum: pkg={{ item }} state=installed
-            sudo: yes
+          - name: Install dependencies
+            package:
+              name:
+                - git
+                - python36-virtualenv
+                - python3
+              state: present
+            become: true
             when: ansible_os_family = 'RedHat'
-            with_items:
-              - git
-              - python-virtualenv
         roles:
           - galaxyproject.pulsar
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,11 @@ the `pip_virtualenv_command` variable.
 [venv]: http://virtualenv.readthedocs.org/
 [pip]: http://pip.readthedocs.org/
 
+Breaking Changes
+----------------
+
+As of 1.0.0, installation with git+pip, and from source, are no longer supported.
+
 Role Variables
 --------------
 
@@ -60,17 +65,8 @@ Role Variables
 You can control various things about where you get Pulsar from, what version
 you use, and where its configuration files will be placed:
 
-- `pulsar_pip_install` (default: `false`): For legacy reasons, this role will
-  install Pulsar by cloning it from git. If set to `true`, Pulsar will be
-  installed from pip instead.
 - `pulsar_yaml_config`: a YAML dictionary whose contents will be used to create
   Pulsar's app.yml
-- `pulsar_git_repo` (default: `https://github.com/galaxyproject/pulsar`):
-  Upstream git repository from which Pulsar should be cloned.
-- `pulsar_changeset_id` (default: `master`): A changeset id, tag, branch, or
-  other valid git identifier for which changeset Pulsar should be updated to.
-  This is also possible when installing from pip (pulsar will be installed
-  using the `git+https://` pip scheme).
 - `pulsar_venv_dir` (default: `<pulsar_server_dir>/venv` if installing via pip,
   `<pulsar_server_dir>/.venv` if not): The role will create a
   [virtualenv][virtualenv] from which Pulsar will run, this controls where the
@@ -83,6 +79,21 @@ you use, and where its configuration files will be placed:
   you are enabling.
 - `pulsar_install_environments` (default: None): Installing dependencies may
   require setting certain environment variables to compile successfully.
+
+
+**User management and privilege separation**
+
+- `pulsar_separate_privileges` (default: `no`): Enable privilege separation mode.
+- `pulsar_user` (default: user running ansible): The name of the system user under which pulsar runs. (or, `{name: pulsar, shell: /bin/bash}`)
+- `pulsar_privsep_user` (default: `root`): The name of the system user that owns the pulsar code, config files, and
+  virtualenv (and dependencies therein).
+- `pulsar_group`: Common group between the pulsar user and privilege separation
+  user. If set directories containing potentially sensitive information such as
+  the pulsar config file will be created group- but not world-readable.
+  Otherwise, directories are created world-readable.
+- `pulsar_create_user` (default: `no`): Create the pulsar user. Running as a dedicated user is a best practice, but most
+  production pulsar instances submitting jobs to a cluster will manage users in a directory service (e.g.  LDAP). This
+  option is useful for standalone servers. Requires superuser privileges.
 
 
 Additional options from Pulsar's `server.ini` are configurable via the

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -112,3 +112,9 @@ __pulsar_privsep_user_name: "{{ pulsar_privsep_user.name | default(pulsar_privse
 # If `pulsar_create_user` is enabled, the privsep user will also be created, but you can override this behavior
 pulsar_create_privsep_user: "{{ pulsar_create_user if __pulsar_privsep_user_name != 'root' else false }}"
 
+# Directories to create as the Pulsar user
+pulsar_dirs:
+  - "{{ pulsar_dependencies_dir }}"
+  - "{{ pulsar_persistence_dir }}"
+  - "{{ pulsar_staging_dir }}"
+  - "{{ pulsar_config_dir }}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,7 @@
 ---
 # defaults file for galaxyproject.pulsar
+pulsar_package_name: pulsar-app
+#pulsar_package_version:
 
 # High-level Pulsar configuration parameters
 pulsar_job_managers_config: "{{ pulsar_config_dir }}/job_managers.ini"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,8 +2,6 @@
 # defaults file for galaxyproject.pulsar
 
 # High-level Pulsar configuration parameters
-pulsar_pip_install: false
-pulsar_git_repo: https://github.com/galaxyproject/pulsar
 pulsar_job_managers_config: "{{ pulsar_config_dir }}/job_managers.ini"
 pulsar_job_metrics_config_file: "{{ pulsar_config_dir }}/job_metrics_conf.xml"
 
@@ -44,3 +42,68 @@ pulsar_install_environments: {}
 pulsar_systemd: false
 pulsar_systemd_enabled: true
 pulsar_systemd_state: started
+pulsar_systemd_memory_limit: 6 # Gigabytes
+
+#
+# Access method control
+#
+
+# The role needs to perform tasks as different users depending on your configuration and how you are connecting to the
+# target host. Keys are the privileges needed and the values are the user to connect as or become:
+#
+#   root: Tasks that require "root" privileges such as creating/chowning directories inside directories owned by root
+#   pulsar: Tasks that run as the pulsar user
+#   privsep: Tasks that run as the privilege separation user
+#   errdocs: Tasks that install error docs (run as whatever user owns these)
+#
+# You would most commonly connect to the target host either as root or as a user with full sudo privileges, but if not
+# using privilege separation, it is possible to run this role as an unprivileged user with no escalation. In such a
+# case, set `pulsar_become_users` to an empty hash like so:
+#
+#pulsar_become_users: {}
+
+# Attempt to automatically decide whether to use `become` and which users to `become`. To disable, set
+# `pulsar_become_users` to an empty hash.
+__pulsar_privsep_user: "{{ pulsar_privsep_user if pulsar_separate_privileges else pulsar_user }}"
+# this goes through two levels of variables since there's no "else if"
+__pulsar_default_root_become_users:
+  pulsar: "{{ __pulsar_user_name }}"
+  privsep: "{{ __pulsar_privsep_user_name }}"
+__pulsar_default_nonroot_become_users:
+  root: root
+  pulsar: "{{ __pulsar_user_name }}"
+  privsep: "{{ __pulsar_privsep_user_name }}"
+__pulsar_default_become_users: "{{ __pulsar_default_root_become_users if ansible_user_uid == 0 else __pulsar_default_nonroot_become_users }}"
+pulsar_become_users: "{{ {} if ansible_user_id == __pulsar_user_name and not pulsar_separate_privileges else __pulsar_default_become_users }}"
+
+# Some sites do not allow the use of passwordless `sudo` and require logging directly in to accounts using `ssh`, this
+# variable works like `pulsar_become_users` and accommodates such scenarios (if using you probably want to set
+# `pulsar_become_users` to an empty hash)
+pulsar_remote_users: {}
+
+#
+# Privilege separation, user and path management
+#
+
+# Privilege separation mode switch
+pulsar_separate_privileges: no
+
+# User that pulsar runs as
+pulsar_user: "{{ ansible_user_id }}"
+
+# User that owns pulsar code, configs, and virutalenv, and that runs `pip install` for dependencies
+pulsar_privsep_user: root
+
+# No explicit group is created by default, system policy will decide users' groups. However, in order to enable
+# privilege separation without making configs world-readable, the users should share a common group. This group will be
+# created if `pulsar_create_user` is enabled and it does not exist. Ideally this is the primary group of `pulsar_user`,
+# on most Linux systems, just set this to the same value as `pulsar_user` if you want to enable this feature.
+#pulsar_group:
+
+# Because these vars can be either a bare username or a dict
+__pulsar_user_name: "{{ pulsar_user.name | default(pulsar_user) }}"
+__pulsar_privsep_user_name: "{{ pulsar_privsep_user.name | default(pulsar_privsep_user) }}"
+
+# If `pulsar_create_user` is enabled, the privsep user will also be created, but you can override this behavior
+pulsar_create_privsep_user: "{{ pulsar_create_user if __pulsar_privsep_user_name != 'root' else false }}"
+

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -44,6 +44,11 @@ pulsar_systemd_enabled: true
 pulsar_systemd_state: started
 pulsar_systemd_memory_limit: 6 # Gigabytes
 
+
+# User management
+pulsar_create_user: no
+
+
 #
 # Access method control
 #

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,0 +1,7 @@
+---
+# defaults file for galaxyproject.galaxy
+
+# TODO: Magical restarters depending on how you're running pulsar.
+- name: default restart pulsar handler
+  debug:
+    msg: "RESTARTER NOT IMPLEMENTED - Please restart pulsar manually. You can define your own handler and enable it with `pulsar_restart_handler_name`"

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,7 +1,12 @@
 ---
-# defaults file for galaxyproject.galaxy
-
 # TODO: Magical restarters depending on how you're running pulsar.
 - name: default restart pulsar handler
   debug:
     msg: "RESTARTER NOT IMPLEMENTED - Please restart pulsar manually. You can define your own handler and enable it with `pulsar_restart_handler_name`"
+  when: not pulsar_systemd
+
+- name: default restart pulsar handler
+  systemd:
+    name: pulsar.service
+    state: started
+  when: pulsar_systemd

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -1,0 +1,50 @@
+---
+# Manage config files
+
+- name: Static config setup
+  block:
+
+    - name: Create Pulsar config dir
+      file:
+        state: directory
+        path: "{{ pulsar_config_dir }}"
+      notify:
+        - "{{ pulsar_restart_handler_name | default('default restart pulsar handler') }}"
+
+    - name: Create Pulsar app configuration file
+      template:
+        src: app.yml.j2
+        dest: "{{ pulsar_config_dir }}/app.yml"
+        mode: 0444
+        backup: yes
+      when: pulsar_yaml_config is defined
+      notify:
+        - "{{ pulsar_restart_handler_name | default('default restart pulsar handler') }}"
+
+    - name: Create Pulsar job manager configuration file
+      template:
+        src: "job_managers.ini.j2"
+        dest: "{{ pulsar_job_managers_config }}"
+        mode: 0444
+        backup: yes
+      when: pulsar_job_managers is defined
+      notify:
+        - "{{ pulsar_restart_handler_name | default('default restart pulsar handler') }}"
+
+    - name: Create additional Pulsar config files
+      template:
+        src: "{{ item }}.j2"
+        dest: "{{ pulsar_config_dir }}/{{ item }}"
+        mode: 0444
+        backup: yes
+      with_items:
+        - server.ini
+        - local_env.sh
+        - job_metrics_conf.xml
+        - dependency_resolvers_conf.xml
+      notify:
+        - "{{ pulsar_restart_handler_name | default('default restart pulsar handler') }}"
+
+  remote_user: "{{ pulsar_remote_users.privsep | default(__pulsar_remote_user) }}"
+  become: "{{ true if pulsar_become_users.privsep is defined else __pulsar_become }}"
+  become_user: "{{ pulsar_become_users.privsep | default(__pulsar_become_user) }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,90 +4,27 @@
 # Deploy a Pulsar server
 #   http://pulsar.readthedocs.org/
 
+# COPIED FROM GALAXY
+# To my knowledge there is no other way to know whether or not the consumer of
+# this role has set `become: true` outside this role, and `become: {{ foo |
+# default(omit) }}` on a task/block actually clobbers the higher level use of
+# `become`. This is a temporary solution.
+
+- name: Set privilege separation default variables
+  set_fact:
+    __pulsar_remote_user: "{{ ansible_user | default(omit) }}"
+    __pulsar_become: "{{ ansible_env.SUDO_USER is defined }}"
+    __pulsar_become_user: "{{ ansible_user_id | default(omit) }}"
+
+- name: Include user creation tasks
+  include_tasks: user.yml
+  when: pulsar_create_user or pulsar_create_privsep_user
+
 - name: Include virtualenv setup tasks
-  import_tasks: virtualenv.yml
+  include_tasks: virtualenv.yml
 
-- name: Create/update virtualenv
-  pip:
-    name: "{{ item }}"
-    state: latest
-    extra_args: "{{ pip_extra_args | default('') }}"
-    virtualenv_command: "{{ pulsar_virtualenv_command | default(pip_virtualenv_command | default(omit)) }}"
-    virtualenv_python: "{{ pulsar_virtualenv_python | default(omit) }}"
-  environment:
-    VIRTUAL_ENV: "{{ pulsar_venv_dir }}"
-  with_items:
-    - pip
-    - setuptools
-  when: pulsar_pip_install == true
-
-- name: Install Pulsar (git+pip)
-  pip:
-    name: "{{ 'git+' ~ pulsar_git_repo ~ '@' ~ pulsar_changeset_id ~ '#egg=pulsar-app' }}"
-    editable: false
-    state: forcereinstall
-  when: pulsar_pip_install == true and pulsar_changeset_id is defined
-
-- name: Install Pulsar (pip)
-  pip:
-    name: pulsar-app
-    state: latest
-    virtualenv: "{{ pulsar_venv_dir }}"
-    extra_args: "{{ pip_extra_args | default('') }}"
-    virtualenv_command: "{{ pulsar_virtualenv_command | default(pip_virtualenv_command | default(omit)) }}"
-    virtualenv_python: "{{ pulsar_virtualenv_python | default(omit) }}"
-  environment:
-    PYTHONPATH: null
-    VIRTUAL_ENV: "{{ pulsar_venv_dir }}"
-  when: pulsar_pip_install == true and pulsar_changeset_id is not defined
-
-- name: Install Pulsar (source)
-  git: dest={{ pulsar_server_dir }} force=no repo={{ pulsar_git_repo }} version={{ pulsar_changeset_id | default('master') }} executable={{ git_executable | default(omit) }}
-  when: pulsar_pip_install == false
-
-- name: Install Pulsar base dependencies for source install
-  pip:
-    requirements: "{{ pulsar_server_dir }}/requirements.txt"
-    virtualenv: "{{ pulsar_venv_dir }}"
-    extra_args: "{{ pip_extra_args | default('') }}"
-    virtualenv_command: "{{ pulsar_virtualenv_command | default(pip_virtualenv_command | default(omit)) }}"
-    virtualenv_python: "{{ pulsar_virtualenv_python | default(omit) }}"
-  environment:
-    PYTHONPATH: null
-    VIRTUAL_ENV: "{{ pulsar_venv_dir }}"
-  when: pulsar_pip_install == false
-
-- name: Install Pulsar dependencies (optional)
-  pip:
-    name: "{{ item }}"
-    virtualenv: "{{ pulsar_venv_dir }}"
-    extra_args: "{{ pip_extra_args | default('') }}"
-    virtualenv_command: "{{ pulsar_virtualenv_command | default(pip_virtualenv_command | default(omit)) }}"
-    virtualenv_python: "{{ pulsar_virtualenv_python | default(omit) }}"
-  environment:
-    PYTHONPATH: null
-    VIRTUAL_ENV: "{{ pulsar_venv_dir }}"
-  #environment: "{{ pulsar_install_environments[item.split('=')[0]] if item.split('=')[0] in pulsar_install_environments else {} }}"
-  with_items: "{{ pulsar_optional_dependencies }}"
-
-- name: Create Pulsar config dir
-  file: state=directory path={{ pulsar_config_dir }}
-
-- name: Create Pulsar app configuration file
-  template: src=app.yml.j2 dest={{ pulsar_config_dir }}/app.yml mode=0444 backup=yes
-  when: pulsar_yaml_config is defined
-
-- name: Create Pulsar job manager configuration file
-  template: src=job_managers.ini.j2 dest={{ pulsar_job_managers_config }} mode=0444 backup=yes
-  when: pulsar_job_managers is defined
-
-- name: Create additional Pulsar config files
-  template: src={{ item }}.j2 dest={{ pulsar_config_dir }}/{{ item }} mode=0444 backup=yes
-  with_items:
-    - server.ini
-    - local_env.sh
-    - job_metrics_conf.xml
-    - dependency_resolvers_conf.xml
+- name: Include config files tasks
+  include_tasks: configure.yml
 
 - include_tasks: systemd.yml
   when: pulsar_systemd

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -20,6 +20,9 @@
   include_tasks: user.yml
   when: pulsar_create_user or pulsar_create_privsep_user
 
+- name: Include path management tasks
+  include_tasks: paths.yml
+
 - name: Include virtualenv setup tasks
   include_tasks: virtualenv.yml
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,6 +4,18 @@
 # Deploy a Pulsar server
 #   http://pulsar.readthedocs.org/
 
+
+# More copying from galaxy role:
+# To my knowledge there is no other way to know whether or not the consumer of
+# this role has set `become: true` outside this role, and `become: {{ foo |
+# default(omit) }}` on a task/block actually clobbers the higher level use of
+# `become`. This is a temporary solution.
+- name: Set privilege separation default variables
+  set_fact:
+    __pulsar_remote_user: "{{ ansible_user | default(omit) }}"
+    __pulsar_become: "{{ ansible_env.SUDO_USER is defined }}"
+    __pulsar_become_user: "{{ ansible_user_id | default(omit) }}"
+
 - name: Include virtualenv setup tasks
   import_tasks: virtualenv.yml
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,18 +4,6 @@
 # Deploy a Pulsar server
 #   http://pulsar.readthedocs.org/
 
-
-# More copying from galaxy role:
-# To my knowledge there is no other way to know whether or not the consumer of
-# this role has set `become: true` outside this role, and `become: {{ foo |
-# default(omit) }}` on a task/block actually clobbers the higher level use of
-# `become`. This is a temporary solution.
-- name: Set privilege separation default variables
-  set_fact:
-    __pulsar_remote_user: "{{ ansible_user | default(omit) }}"
-    __pulsar_become: "{{ ansible_env.SUDO_USER is defined }}"
-    __pulsar_become_user: "{{ ansible_user_id | default(omit) }}"
-
 - name: Include virtualenv setup tasks
   import_tasks: virtualenv.yml
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -50,7 +50,7 @@
     virtualenv_python: "{{ pulsar_virtualenv_python | default(omit) }}"
   environment:
     PYTHONPATH: null
-    VIRTUAL_ENV: "{{ galaxy_venv_dir }}"
+    VIRTUAL_ENV: "{{ pulsar_venv_dir }}"
   when: pulsar_pip_install == true and pulsar_changeset_id is not defined
 
 - name: Install Pulsar (source)
@@ -66,7 +66,7 @@
     virtualenv_python: "{{ pulsar_virtualenv_python | default(omit) }}"
   environment:
     PYTHONPATH: null
-    VIRTUAL_ENV: "{{ galaxy_venv_dir }}"
+    VIRTUAL_ENV: "{{ pulsar_venv_dir }}"
   when: pulsar_pip_install == false
 
 - name: Install Pulsar dependencies (optional)
@@ -78,7 +78,7 @@
     virtualenv_python: "{{ pulsar_virtualenv_python | default(omit) }}"
   environment:
     PYTHONPATH: null
-    VIRTUAL_ENV: "{{ galaxy_venv_dir }}"
+    VIRTUAL_ENV: "{{ pulsar_venv_dir }}"
   #environment: "{{ pulsar_install_environments[item.split('=')[0]] if item.split('=')[0] in pulsar_install_environments else {} }}"
   with_items: "{{ pulsar_optional_dependencies }}"
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,20 +4,18 @@
 # Deploy a Pulsar server
 #   http://pulsar.readthedocs.org/
 
-- name: Ensure pip and virtualenv commands are available
-  package:
-    name: "{{ item }}"
-    state: installed
-  with_items:
-    - python-pip
-    - python-virtualenv
+- name: Include virtualenv setup tasks
+  import_tasks: virtualenv.yml
 
 - name: Create/update virtualenv
   pip:
     name: "{{ item }}"
     state: latest
-    virtualenv: "{{ pulsar_venv_dir }}"
-    virtualenv_command: "{{ pip_virtualenv_command | default(omit) }}"
+    extra_args: "{{ pip_extra_args | default('') }}"
+    virtualenv_command: "{{ pulsar_virtualenv_command | default(pip_virtualenv_command | default(omit)) }}"
+    virtualenv_python: "{{ pulsar_virtualenv_python | default(omit) }}"
+  environment:
+    VIRTUAL_ENV: "{{ pulsar_venv_dir }}"
   with_items:
     - pip
     - setuptools
@@ -26,7 +24,6 @@
 - name: Install Pulsar (git+pip)
   pip:
     name: "{{ 'git+' ~ pulsar_git_repo ~ '@' ~ pulsar_changeset_id ~ '#egg=pulsar-app' }}"
-    virtualenv: "{{ pulsar_venv_dir }}"
     editable: false
     state: forcereinstall
   when: pulsar_pip_install == true and pulsar_changeset_id is defined
@@ -36,6 +33,12 @@
     name: pulsar-app
     state: latest
     virtualenv: "{{ pulsar_venv_dir }}"
+    extra_args: "{{ pip_extra_args | default('') }}"
+    virtualenv_command: "{{ pulsar_virtualenv_command | default(pip_virtualenv_command | default(omit)) }}"
+    virtualenv_python: "{{ pulsar_virtualenv_python | default(omit) }}"
+  environment:
+    PYTHONPATH: null
+    VIRTUAL_ENV: "{{ galaxy_venv_dir }}"
   when: pulsar_pip_install == true and pulsar_changeset_id is not defined
 
 - name: Install Pulsar (source)
@@ -43,11 +46,27 @@
   when: pulsar_pip_install == false
 
 - name: Install Pulsar base dependencies for source install
-  pip: requirements={{ pulsar_server_dir }}/requirements.txt virtualenv={{ pulsar_venv_dir }} virtualenv_command={{ pip_virtualenv_command | default(omit) }}
+  pip:
+    requirements: "{{ pulsar_server_dir }}/requirements.txt"
+    virtualenv: "{{ pulsar_venv_dir }}"
+    extra_args: "{{ pip_extra_args | default('') }}"
+    virtualenv_command: "{{ pulsar_virtualenv_command | default(pip_virtualenv_command | default(omit)) }}"
+    virtualenv_python: "{{ pulsar_virtualenv_python | default(omit) }}"
+  environment:
+    PYTHONPATH: null
+    VIRTUAL_ENV: "{{ galaxy_venv_dir }}"
   when: pulsar_pip_install == false
 
 - name: Install Pulsar dependencies (optional)
-  pip: name={{ item }} virtualenv={{ pulsar_venv_dir }} virtualenv_command={{ pip_virtualenv_command | default(omit) }}
+  pip:
+    name: "{{ item }}"
+    virtualenv: "{{ pulsar_venv_dir }}"
+    extra_args: "{{ pip_extra_args | default('') }}"
+    virtualenv_command: "{{ pulsar_virtualenv_command | default(pip_virtualenv_command | default(omit)) }}"
+    virtualenv_python: "{{ pulsar_virtualenv_python | default(omit) }}"
+  environment:
+    PYTHONPATH: null
+    VIRTUAL_ENV: "{{ galaxy_venv_dir }}"
   #environment: "{{ pulsar_install_environments[item.split('=')[0]] if item.split('=')[0] in pulsar_install_environments else {} }}"
   with_items: "{{ pulsar_optional_dependencies }}"
 

--- a/tasks/paths.yml
+++ b/tasks/paths.yml
@@ -41,15 +41,6 @@
         mode: "{{ __pulsar_dir_perms }}"
       when: pulsar_root is defined
 
-    - name: Create additional privilege separated directories
-      file:
-        path: "{{ item }}"
-        state: directory
-        owner: "{{ __pulsar_privsep_user_name }}"
-        group: "{{ __pulsar_privsep_user_group }}"
-        mode: "{{ __pulsar_dir_perms }}"
-      with_items: "{{ pulsar_privsep_dirs }}"
-
     - name: Create additional directories
       file:
         path: "{{ item }}"

--- a/tasks/paths.yml
+++ b/tasks/paths.yml
@@ -1,0 +1,65 @@
+---
+- name: Manage Paths
+  block:
+
+    - name: Get group IDs for pulsar users
+      getent:
+        database: passwd
+        key: "{{ item }}"
+      with_items:
+        - "{{ __pulsar_user_name }}"
+        - "{{ __pulsar_privsep_user_name }}"
+      when: pulsar_group is not defined
+      register: __pulsar_passwd_result
+
+    - name: Get group names for pulsar users
+      getent:
+        database: group
+        key: "{{ item.ansible_facts.getent_passwd[item.invocation.module_args.key][2] }}"
+      with_items: "{{ __pulsar_passwd_result.results }}"
+      loop_control:
+        label: "{{ item.item }}"
+      when: pulsar_group is not defined
+      register: __pulsar_group_result
+
+    - name: Set pulsar user facts
+      set_fact:
+        __pulsar_user_group: "{{ ((pulsar_group | default({})).name | default(pulsar_group)) if pulsar_group is defined else (__pulsar_group_result.results[0].ansible_facts.getent_group.keys() | first) }}"
+        __pulsar_privsep_user_group: "{{ ((pulsar_group | default({})).name | default(pulsar_group)) if pulsar_group is defined else (__pulsar_group_result.results[1].ansible_facts.getent_group.keys() | first) }}"
+
+    - name: Determine whether to restrict to group permissions
+      set_fact:
+        __pulsar_dir_perms: "{{ '0750' if __pulsar_user_group == __pulsar_privsep_user_group else '0755' }}"
+
+    # try to become root. if you need something fancier, don't use the role and write your own
+    - name: Create pulsar_root
+      file:
+        path: "{{ pulsar_root }}"
+        state: directory
+        owner: "{{ __pulsar_privsep_user_name }}"
+        group: "{{ __pulsar_privsep_user_group }}"
+        mode: "{{ __pulsar_dir_perms }}"
+      when: pulsar_root is defined
+
+    - name: Create additional privilege separated directories
+      file:
+        path: "{{ item }}"
+        state: directory
+        owner: "{{ __pulsar_privsep_user_name }}"
+        group: "{{ __pulsar_privsep_user_group }}"
+        mode: "{{ __pulsar_dir_perms }}"
+      with_items: "{{ pulsar_privsep_dirs }}"
+
+    - name: Create additional directories
+      file:
+        path: "{{ item }}"
+        state: directory
+        owner: "{{ __pulsar_user_name }}"
+        group: "{{ __pulsar_user_group }}"
+        mode: "{{ __pulsar_dir_perms }}"
+      with_items: "{{ pulsar_dirs }}"
+
+  # TODO: for root squashing it might be useful for this to be separate from other root tasks
+  remote_user: "{{ pulsar_remote_users.root | default(__pulsar_remote_user) }}"
+  become: "{{ true if pulsar_become_users.root is defined else __pulsar_become }}"
+  become_user: "{{ pulsar_become_users.root | default(__pulsar_become_user) }}"

--- a/tasks/systemd.yml
+++ b/tasks/systemd.yml
@@ -1,18 +1,14 @@
 ---
-- name: Setup SystemD
-  block:
-    - name: Create Pulsar systemd unit file
-      template:
-        src: "pulsar.service.j2"
-        dest: "/etc/systemd/system/pulsar.service"
+- name: Create Pulsar systemd unit file
+  template:
+    src: "pulsar.service.j2"
+    dest: "/etc/systemd/system/pulsar.service"
+  become: true
 
-    - name: SystemD daemon-reload and enable/start service
-      systemd:
-        state: "{{ pulsar_systemd_state }}"
-        enabled: "{{ pulsar_systemd_enabled }}"
-        name: pulsar.service
-        daemon_reload: yes
-
-  remote_user: "{{ __pulsar_remote_user }}"
-  become: "{{ __pulsar_become }}"
-  become_user: "{{ __pulsar_become_user }}"
+- name: SystemD daemon-reload and enable/start service
+  systemd:
+    state: "{{ pulsar_systemd_state }}"
+    enabled: "{{ pulsar_systemd_enabled }}"
+    name: pulsar.service
+    daemon_reload: yes
+  become: true

--- a/tasks/systemd.yml
+++ b/tasks/systemd.yml
@@ -1,12 +1,18 @@
 ---
-- name: Create Pulsar systemd unit file
-  template:
-    src: "pulsar.service.j2"
-    dest: "/etc/systemd/system/pulsar.service"
+- name: Setup SystemD
+  block:
+    - name: Create Pulsar systemd unit file
+      template:
+        src: "pulsar.service.j2"
+        dest: "/etc/systemd/system/pulsar.service"
 
-- name: SystemD daemon-reload and enable/start service
-  systemd:
-    state: "{{ pulsar_systemd_state }}"
-    enabled: "{{ pulsar_systemd_enabled }}"
-    name: pulsar.service
-    daemon_reload: yes
+    - name: SystemD daemon-reload and enable/start service
+      systemd:
+        state: "{{ pulsar_systemd_state }}"
+        enabled: "{{ pulsar_systemd_enabled }}"
+        name: pulsar.service
+        daemon_reload: yes
+
+  remote_user: "{{ __pulsar_remote_user }}"
+  become: "{{ __pulsar_become }}"
+  become_user: "{{ __pulsar_become_user }}"

--- a/tasks/systemd.yml
+++ b/tasks/systemd.yml
@@ -1,14 +1,18 @@
 ---
-- name: Create Pulsar systemd unit file
-  template:
-    src: "pulsar.service.j2"
-    dest: "/etc/systemd/system/pulsar.service"
-  become: true
+- name: Setup SystemD
+  block:
+    - name: Create Pulsar systemd unit file
+      template:
+        src: "pulsar.service.j2"
+        dest: "/etc/systemd/system/pulsar.service"
 
-- name: SystemD daemon-reload and enable/start service
-  systemd:
-    state: "{{ pulsar_systemd_state }}"
-    enabled: "{{ pulsar_systemd_enabled }}"
-    name: pulsar.service
-    daemon_reload: yes
-  become: true
+    - name: SystemD daemon-reload and enable/start service
+      systemd:
+        state: "{{ pulsar_systemd_state }}"
+        enabled: "{{ pulsar_systemd_enabled }}"
+        name: pulsar.service
+        daemon_reload: yes
+
+  remote_user: "{{ pulsar_remote_users.root | default(__pulsar_remote_user) }}"
+  become: "{{ true if pulsar_become_users.root is defined else __pulsar_become }}"
+  become_user: "{{ pulsar_become_users.root | default(__pulsar_become_user) }}"

--- a/tasks/user.yml
+++ b/tasks/user.yml
@@ -1,0 +1,41 @@
+---
+- name: Create users
+  block:
+
+    - name: Create pulsar group
+      group:
+        name: "{{ pulsar_group.name | default(pulsar_group) }}"
+        gid: "{{ pulsar_group.gid | default(omit) }}"
+        system: "{{ pulsar_group.system | default(pulsar_user.system) | default('true') }}"
+        local: "{{ pulsar_group.local | default(pulsar_user.local) | default(omit) }}"
+      when: pulsar_group is defined
+
+    - name: Create pulsar user
+      user:
+        name: "{{ pulsar_user.name | default(pulsar_user) }}"
+        uid: "{{ pulsar_user.uid | default(omit) }}"
+        group: "{{ (pulsar_group | default({})).name | default(pulsar_group) | default(omit) }}"
+        comment: "{{ pulsar_user.comment | default('pulsar server') }}"
+        create_home: "{{ pulsar_user.create_home | default('true') }}"
+        home: "{{ pulsar_user.home | default(omit) }}"
+        shell: "{{ pulsar_user.shell | default(omit) }}"
+        system: "{{ pulsar_user.system | default('true') }}"
+        local: "{{ pulsar_user.local | default(omit) }}"
+      when: pulsar_create_user
+
+    - name: Create pulsar privilege separation user
+      user:
+        name: "{{ pulsar_privsep_user.name | default(pulsar_privsep_user) }}"
+        uid: "{{ pulsar_privsep_user.uid | default(omit) }}"
+        group: "{{ (pulsar_group | default({})).name | default(pulsar_group) | default(omit) }}"
+        comment: "{{ pulsar_privsep_user.comment | default('pulsar server privilege separation') }}"
+        create_home: "{{ pulsar_privsep_user.create_home | default('true') }}"
+        home: "{{ pulsar_privsep_user.home | default(omit) }}"
+        shell: "{{ pulsar_privsep_user.shell | default(omit) }}"
+        system: "{{ pulsar_privsep_user.system | default('true') }}"
+        local: "{{ pulsar_privsep_user.local | default(omit) }}"
+      when: pulsar_create_privsep_user
+
+  remote_user: "{{ pulsar_remote_users.root | default(__pulsar_remote_user) }}"
+  become: "{{ true if pulsar_become_users.root is defined else __pulsar_become }}"
+  become_user: "{{ pulsar_become_users.root | default(__pulsar_become_user) }}"

--- a/tasks/virtualenv.yml
+++ b/tasks/virtualenv.yml
@@ -31,7 +31,8 @@
 
     - name: Install Pulsar
       pip:
-        name: pulsar-app
+        name: "{{ pulsar_package_name }}"
+        vesion: "{{ pulsar_package_version | default(omit) }}"
         state: latest
         virtualenv: "{{ pulsar_venv_dir }}"
         extra_args: "{{ pip_extra_args | default('') }}"

--- a/tasks/virtualenv.yml
+++ b/tasks/virtualenv.yml
@@ -1,0 +1,27 @@
+---
+# Copied from galaxyproject.galaxy
+#
+# Having pip installed on $PYTHONPATH can break upgrading it, so we install
+# once with $PYTHONPATH set (in case it's needed for virtualenv) and then once
+# the venv is created we upgrade pip with $PYTHONPATH unset
+
+- name: Create Pulsar virtualenv
+  pip:
+    name: pip
+    virtualenv: "{{ pulsar_venv_dir }}"
+    extra_args: "{{ pip_extra_args | default('') }}"
+    virtualenv_command: "{{ pulsar_virtualenv_command | default(pip_virtualenv_command | default(omit)) }}"
+    virtualenv_python: "{{ pulsar_virtualenv_python | default(omit) }}"
+  environment:
+    VIRTUAL_ENV: "{{ pulsar_venv_dir }}"
+
+- name: Ensure pip is the latest release
+  pip:
+    name: pip
+    state: latest
+    extra_args: "{{ pip_extra_args | default('') }}"
+    virtualenv: "{{ pulsar_venv_dir }}"
+    virtualenv_command: "{{ pulsar_virtualenv_command | default(pip_virtualenv_command | default(omit)) }}"
+  environment:
+    PYTHONPATH: null
+    VIRTUAL_ENV: "{{ pulsar_venv_dir }}"

--- a/tasks/virtualenv.yml
+++ b/tasks/virtualenv.yml
@@ -32,7 +32,7 @@
     - name: Install Pulsar
       pip:
         name: "{{ pulsar_package_name }}"
-        vesion: "{{ pulsar_package_version | default(omit) }}"
+        version: "{{ pulsar_package_version | default(omit) }}"
         state: latest
         virtualenv: "{{ pulsar_venv_dir }}"
         extra_args: "{{ pip_extra_args | default('') }}"

--- a/tasks/virtualenv.yml
+++ b/tasks/virtualenv.yml
@@ -5,23 +5,53 @@
 # once with $PYTHONPATH set (in case it's needed for virtualenv) and then once
 # the venv is created we upgrade pip with $PYTHONPATH unset
 
-- name: Create Pulsar virtualenv
-  pip:
-    name: pip
-    virtualenv: "{{ pulsar_venv_dir }}"
-    extra_args: "{{ pip_extra_args | default('') }}"
-    virtualenv_command: "{{ pulsar_virtualenv_command | default(pip_virtualenv_command | default(omit)) }}"
-    virtualenv_python: "{{ pulsar_virtualenv_python | default(omit) }}"
-  environment:
-    VIRTUAL_ENV: "{{ pulsar_venv_dir }}"
+- name: Manage dependencies
+  block:
 
-- name: Ensure pip is the latest release
-  pip:
-    name: pip
-    state: latest
-    extra_args: "{{ pip_extra_args | default('') }}"
-    virtualenv: "{{ pulsar_venv_dir }}"
-    virtualenv_command: "{{ pulsar_virtualenv_command | default(pip_virtualenv_command | default(omit)) }}"
-  environment:
-    PYTHONPATH: null
-    VIRTUAL_ENV: "{{ pulsar_venv_dir }}"
+    - name: Create Pulsar virtualenv
+      pip:
+        name: pip
+        virtualenv: "{{ pulsar_venv_dir }}"
+        extra_args: "{{ pip_extra_args | default('') }}"
+        virtualenv_command: "{{ pulsar_virtualenv_command | default(pip_virtualenv_command | default(omit)) }}"
+        virtualenv_python: "{{ pulsar_virtualenv_python | default(omit) }}"
+      environment:
+        VIRTUAL_ENV: "{{ pulsar_venv_dir }}"
+
+    - name: Ensure pip is the latest release
+      pip:
+        name: pip
+        state: latest
+        extra_args: "{{ pip_extra_args | default('') }}"
+        virtualenv: "{{ pulsar_venv_dir }}"
+        virtualenv_command: "{{ pulsar_virtualenv_command | default(pip_virtualenv_command | default(omit)) }}"
+      environment:
+        PYTHONPATH: null
+        VIRTUAL_ENV: "{{ pulsar_venv_dir }}"
+
+    - name: Install Pulsar
+      pip:
+        name: pulsar-app
+        state: latest
+        virtualenv: "{{ pulsar_venv_dir }}"
+        extra_args: "{{ pip_extra_args | default('') }}"
+        virtualenv_command: "{{ pulsar_virtualenv_command | default(pip_virtualenv_command | default(omit)) }}"
+        virtualenv_python: "{{ pulsar_virtualenv_python | default(omit) }}"
+      environment:
+        PYTHONPATH: null
+        VIRTUAL_ENV: "{{ pulsar_venv_dir }}"
+
+    - name: Install Pulsar dependencies (optional)
+      pip:
+        name: "{{ pulsar_optional_dependencies }}"
+        virtualenv: "{{ pulsar_venv_dir }}"
+        extra_args: "{{ pip_extra_args | default('') }}"
+        virtualenv_command: "{{ pulsar_virtualenv_command | default(pip_virtualenv_command | default(omit)) }}"
+        virtualenv_python: "{{ pulsar_virtualenv_python | default(omit) }}"
+      environment:
+        PYTHONPATH: null
+        VIRTUAL_ENV: "{{ pulsar_venv_dir }}"
+
+  remote_user: "{{ pulsar_remote_users.privsep | default(__pulsar_remote_user) }}"
+  become: "{{ true if pulsar_become_users.privsep is defined else __pulsar_become }}"
+  become_user: "{{ pulsar_become_users.privsep | default(__pulsar_become_user) }}"

--- a/templates/pulsar.service.j2
+++ b/templates/pulsar.service.j2
@@ -1,10 +1,23 @@
 [Unit]
 Description=Pulsar
-After=syslog.target network.target
+After=network.target
+After=time-sync.target
+After=syslog.target
 
 [Service]
+UMask=022
 Type=simple
+User={{ __pulsar_user_name }}
+Group={{ __pulsar_user_group }}
+WorkingDirectory={{ pulsar_server_dir }}
+TimeoutStartSec=30
 ExecStart={{ pulsar_venv_dir }}/bin/python {{ pulsar_venv_dir }}/bin/paster serve {{ pulsar_config_dir }}/server.ini
+MemoryLimit={{ pulsar_systemd_memory_limit }}G
+Restart=always
+
+MemoryAccounting=yes
+CPUAccounting=yes
+BlockIOAccounting=yes
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
- fixes #4 
- virtualenv stuff that might not be necessary, from galaxy
- force `become: true` on systemd, not a good solution

with virtualenv/python3 installed, things seemed to work once I removed the stupid "install venv if missing" task I added a while back for unclear reasons. It's just a hard requirement that it be there.