### PR TITLE
Fix error when running

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,7 +12,7 @@
 
 - name: Set privilege separation default variables
   set_fact:
-    __pulsar_remote_user: "{{ ansible_user | default(omit) }}"
+    __pulsar_remote_user: "{{ ansible_user_id | default(omit) }}"
     __pulsar_become: "{{ ansible_env.SUDO_USER is defined }}"
     __pulsar_become_user: "{{ ansible_user_id | default(omit) }}"
 

--- a/templates/pulsar.service.j2
+++ b/templates/pulsar.service.j2
@@ -11,7 +11,7 @@ User={{ __pulsar_user_name }}
 Group={{ __pulsar_user_group }}
 WorkingDirectory={{ pulsar_server_dir }}
 TimeoutStartSec=30
-ExecStart={{ pulsar_venv_dir }}/bin/python {{ pulsar_venv_dir }}/bin/paster serve {{ pulsar_config_dir }}/server.ini
+ExecStart={{ pulsar_venv_dir }}/bin/uwsgi --ini-paste {{ pulsar_config_dir }}/server.ini
 MemoryLimit={{ pulsar_systemd_memory_limit }}G
 Restart=always
 


### PR DESCRIPTION
@natefoo can you please check this? It crashed during testing, and `ansible -m setup` doesn't show an `ansible_user` variable, and `ansible_user_id` is used consistently elsewhere, but I copied this directly from the galaxy role.

