### PR TITLE
missing drmaa_lib env in systemd file

### DIFF
--- a/tasks/systemd.yml
+++ b/tasks/systemd.yml
@@ -3,7 +3,7 @@
   block:
     - name: Create Pulsar systemd unit file
       template:
-        src: "pulsar.service.j2"
+        src: "{{pulsar_systemd_file}}"
         dest: "/etc/systemd/system/pulsar.service"
 
     - name: SystemD daemon-reload and enable/start service

--- a/templates/pulsar.service.j2
+++ b/templates/pulsar.service.j2
@@ -16,6 +16,9 @@ ExecStart={{ pulsar_venv_dir }}/bin/python {{ pulsar_venv_dir }}/bin/paster serv
 {% else %}
 ExecStart={{ pulsar_venv_dir }}/bin/uwsgi --ini-paste {{ pulsar_config_dir }}/server.ini
 {% endif %}
+{% if pulsar_drmaa_library_path %}
+Environment=DRMAA_LIBRARY_PATH={{pulsar_drmaa_library_path}}
+{% endif %}
 MemoryLimit={{ pulsar_systemd_memory_limit }}G
 Restart=always
 


### PR DESCRIPTION
This sets the missing environmental vairable DRMAA_LIBRARY_PATH to pulsar_drmaa_library_path if this is sat in the playbook.

Otherwise pulsar cannot find the drmaa library when run through systemd

Also made the file template as an ansible variable so it can easier be modified without changing the ansible role

