### PR TITLE
Webless mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,8 @@ Install Pulsar with directory separation and also install Galaxy:
           galaxy_manage_mutable_setup: no
           galaxy_manage_database: no
           
-Install Pulsar with directory separation, systemd service configuration, webless mode and communication via a message queue into a Centos7 host:
+Install Pulsar into a Centos7 host with directory and privilege separation, systemd service configuration, 
+webless mode and communication via a message queue:
 
     - hosts: pulsarservers
       vars:

--- a/README.md
+++ b/README.md
@@ -231,16 +231,16 @@ webless mode and communication via a message queue:
               submit_universe: vanilla
               type: queued_condor    
       pre_tasks:
-      - name: Install dependencies
-        become: yes
-        package:
-          state: latest
-          name:
-          - git
-          - python-virtualenv
-          - python3
-          - curl
-          - libcurl-devel    
+        - name: Install dependencies
+          become: yes
+          package:
+            state: latest
+            name:
+            - git
+            - python-virtualenv
+            - python3
+            - curl
+            - libcurl-devel    
       roles:
         - role: galaxyproject.pulsar
   

--- a/README.md
+++ b/README.md
@@ -196,6 +196,53 @@ Install Pulsar with directory separation and also install Galaxy:
         - role: galaxyproject.galaxy
           galaxy_manage_mutable_setup: no
           galaxy_manage_database: no
+          
+Install Pulsar with directory separation, systemd service configuration, webless mode and communication via a message queue into a Centos7 host:
+
+    - hosts: pulsarservers
+      vars:
+        pulsar_root: /opt/pulsar
+        pulsar_persistence_dir: /var/opt/pulsar/persisted_data
+        pulsar_staging_dir: /var/opt/pulsar/staging
+        pulsar_dependencies_dir: /var/opt/pulsar/deps
+        pulsar_optional_dependencies:
+          - pycurl
+          - kombu
+          - psutil
+        pulsar_systemd: true
+        pulsar_systemd_runner: webless
+        pulsar_separate_privileges: yes
+        pulsar_privsep_user: centos
+        pulsar_yaml_config:
+          conda_auto_init: true
+          conda_auto_install: true
+          assign_ids: none
+          message_queue_url: "message_queue_url"
+          min_polling_interval: 0.5
+          persistence_directory: "{{ pulsar_persistence_dir }}"
+          staging_directory: "{{ pulsar_staging_dir }}"
+          tool_dependency_dir: "{{ pulsar_dependencies_dir }}"
+          managers:
+            production:
+              submit_universe: vanilla
+              type: queued_condor
+            test:
+              submit_universe: vanilla
+              type: queued_condor    
+      pre_tasks:
+      - name: Install dependencies
+        become: yes
+        package:
+          state: latest
+          name:
+          - git
+          - python-virtualenv
+          - python3
+          - curl
+          - libcurl-devel    
+      roles:
+        - role: galaxyproject.pulsar
+  
 
 License
 -------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -69,7 +69,7 @@ pulsar_systemd: false
 pulsar_systemd_enabled: true
 pulsar_systemd_state: started
 pulsar_systemd_memory_limit: 6 # Gigabytes
-pulsar_systemd_runner: paste # Or uWSGI, but uwsgi doesn't restart right.
+pulsar_systemd_runner: paste # Or webless or uWSGI, but uwsgi doesn't restart right.
 
 
 # User management

--- a/templates/pulsar.service.j2
+++ b/templates/pulsar.service.j2
@@ -9,12 +9,12 @@ UMask=022
 Type=simple
 User={{ __pulsar_user_name }}
 Group={{ __pulsar_user_group }}
-WorkingDirectory={{ pulsar_root }}
 TimeoutStartSec=30
 {% if pulsar_systemd_runner == "paste" %}
 ExecStart={{ pulsar_venv_dir }}/bin/python {{ pulsar_venv_dir }}/bin/paster serve {{ pulsar_config_dir }}/server.ini
 {% elif pulsar_systemd_runner == "webless" %}
-ExecStart={{ pulsar_venv_dir }}/bin/pulsar-main --ini_path {{ pulsar_config_dir }}/server.ini
+Environment=PULSAR_VIRTUALENV={{ pulsar_venv_dir }}
+ExecStart={{ pulsar_venv_dir }}/bin/pulsar -c {{ pulsar_config_dir }} -m webless
 {% else %}
 ExecStart={{ pulsar_venv_dir }}/bin/uwsgi --ini-paste {{ pulsar_config_dir }}/server.ini
 {% endif %}

--- a/templates/pulsar.service.j2
+++ b/templates/pulsar.service.j2
@@ -9,7 +9,7 @@ UMask=022
 Type=simple
 User={{ __pulsar_user_name }}
 Group={{ __pulsar_user_group }}
-WorkingDirectory={{ pulsar_server_dir }}
+WorkingDirectory={{ pulsar_root }}
 TimeoutStartSec=30
 {% if pulsar_systemd_runner == "paste" %}
 ExecStart={{ pulsar_venv_dir }}/bin/python {{ pulsar_venv_dir }}/bin/paster serve {{ pulsar_config_dir }}/server.ini

--- a/templates/pulsar.service.j2
+++ b/templates/pulsar.service.j2
@@ -14,7 +14,7 @@ TimeoutStartSec=30
 {% if pulsar_systemd_runner == "paste" %}
 ExecStart={{ pulsar_venv_dir }}/bin/python {{ pulsar_venv_dir }}/bin/paster serve {{ pulsar_config_dir }}/server.ini
 {% elif pulsar_systemd_runner == "webless" %}
-ExecStart={{ pulsar_venv_dir }}/bin/pulsar -m webless -c {{ pulsar_config_dir }}
+ExecStart={{ pulsar_venv_dir }}/bin/pulsar-main --ini_path {{ pulsar_config_dir }}/server.ini
 {% else %}
 ExecStart={{ pulsar_venv_dir }}/bin/uwsgi --ini-paste {{ pulsar_config_dir }}/server.ini
 {% endif %}

--- a/templates/pulsar.service.j2
+++ b/templates/pulsar.service.j2
@@ -13,6 +13,8 @@ WorkingDirectory={{ pulsar_server_dir }}
 TimeoutStartSec=30
 {% if pulsar_systemd_runner == "paste" %}
 ExecStart={{ pulsar_venv_dir }}/bin/python {{ pulsar_venv_dir }}/bin/paster serve {{ pulsar_config_dir }}/server.ini
+{% elif pulsar_systemd_runner == "webless" %}
+ExecStart={{ pulsar_venv_dir }}/bin/pulsar -m webless -c {{ pulsar_config_dir }}
 {% else %}
 ExecStart={{ pulsar_venv_dir }}/bin/uwsgi --ini-paste {{ pulsar_config_dir }}/server.ini
 {% endif %}


### PR DESCRIPTION
 Add webless mode option, useful when Pulsar is configured to listen to a message queue and doesn’t require a web server. The example is derived from what I am doing for the instances of the "Pulsar network".

