### PR TITLE
Attempt to set PYCURL_SSL_LIBRARY

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,6 @@ you use, and where its configuration files will be placed:
 - `pulsar_config_dir` (default: `<pulsar_root>/config`): Directory that will be used for Pulsar configuration files.
 - `pulsar_optional_dependencies` (default: None): List of optional dependency modules to install. Whether or not you
   need these depends on what features you are enabling.
-- `pulsar_install_environments` (default: None): Installing dependencies may require setting certain environment
-  variables to compile successfully.
 
 
 **User management and privilege separation**
@@ -133,20 +131,6 @@ Currently, the list of optional dependencies is:
 Many of these dependencies have their own dependencies. A nice future
 enhancement to this role would be to install the dependencies' dependencies via
 the system package manager if desired.
-
-### pulsar_install_environments ###
-
-Some sites may need to set environment variables when installing certain
-modules, e.g. to point pyOpenSSL at a non-standard OpenSSL or libffi locations,
-or to instruct pycurl to use the NSS library:
-
-    pulsar_install_environments:
-      pyOpenSSL:
-        PKG_CONFIG_PATH: "/opt/site/libffi/lib64/pkgconfig"
-        CFLAGS: "-I/opt/site/openssl/include"
-        LDFLAGS: "-L/opt/site/openssl/lib"
-      pycurl:
-        PYCURL_SSL_LIBRARY: "nss"
 
 [pulsardocs]: http://pulsar.readthedocs.org/
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -58,10 +58,13 @@ pulsar_job_metrics_plugins:
 # List of optional dependency modules to install
 pulsar_optional_dependencies: []
 
-# If development packages dependent to the optional modules (e.g. curl,
-# OpenSSL, libffi) are not installed system wide on destination, environment
-# variables can be used to target other paths.
-pulsar_install_environments: {}
+# PycURL needs to know the SSL backend libcurl is compiled with
+pulsar_pycurl_ssl_library: >-
+  {{
+    'nss' if ansible_os_family == 'RedHat' else (
+    'gnutls' if ansible_os_family == 'Debian' else 'openssl'
+    )
+  }}
 
 # To deploy a systemd unit file
 # pulsar_systemd: true

--- a/tasks/virtualenv.yml
+++ b/tasks/virtualenv.yml
@@ -52,6 +52,7 @@
       environment:
         PYTHONPATH: null
         VIRTUAL_ENV: "{{ pulsar_venv_dir }}"
+        PYCURL_SSL_LIBRARY: "{{ pulsar_pycurl_ssl_library }}"
 
   remote_user: "{{ pulsar_remote_users.privsep | default(__pulsar_remote_user) }}"
   become: "{{ true if pulsar_become_users.privsep is defined else __pulsar_become }}"


### PR DESCRIPTION
...and remove remnants of pulsar_install_environments.

This should do the right thing in most cases, set `pulsar_pycurl_ssl_library` to override as needed.