### PR TITLE
Updates to structured config handling

### DIFF
--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -22,11 +22,9 @@ jobs:
           - image: "centos"
             tag: "7"
           - image: "ubuntu"
-            tag: "16.04"
-          - image: "ubuntu"
             tag: "18.04"
-          #- image: "ubuntu"
-          #  tag: "20.04"
+          - image: "ubuntu"
+            tag: "20.04"
     steps:
       - name: checkout
         uses: actions/checkout@v2

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,18 +5,14 @@ pulsar_package_name: pulsar-app
 
 pulsar_log_level: DEBUG
 
-# High-level Pulsar configuration parameters
-pulsar_job_managers_config: "{{ pulsar_config_dir }}/job_managers.ini"
-pulsar_job_metrics_config_file: "{{ pulsar_config_dir }}/job_metrics_conf.xml"
-
 # For legacy purposes
 pulsar_root: "{{ pulsar_server_dir }}"
 
 # Paths
 pulsar_dependencies_dir: "{{ pulsar_root }}/deps"
-pulsar_venv_dir: "{{ pulsar_root }}/venv"
 pulsar_persistence_dir: "{{ pulsar_root }}/files/persisted_data"
 pulsar_staging_dir: "{{ pulsar_root }}/files/staging"
+pulsar_venv_dir: "{{ pulsar_root }}/venv"
 pulsar_config_dir: "{{ pulsar_root }}/config"
 
 # Optional message queue configuration
@@ -30,22 +26,24 @@ pulsar_port: 8913
 # Optional ssl key for SSL web server
 # pulsar_ssl_pem:
 
-pulsar_dependency_resolvers:
-  - name: conda
-    #args:
-    #  - name: auto_init
-    #    value: true
-  - name: tool_shed_packages
-  - name: galaxy_packages
+# Default options for Pulsar app.yml
+pulsar_yaml_config_default:
+  tool_dependency_dir: "{{ pulsar_dependencies_dir }}"
+  persistence_directory: "{{ pulsar_persistence_dir }}"
+  staging_directory: "{{ pulsar_staging_dir }}"
+  # Static configs that default to .xml files in the config dir but the role writes as .yml if configured
+  job_metrics_config_file: "job_metrics_conf.{{ (pulsar_job_metrics_plugins is defined) | ternary('yml', 'xml') }}"
 
-pulsar_job_metrics_plugins:
-  - name: core
-  - name: cpuinfo
-    args:
-      - name: verbose
-        value: "true"
-  - name: meminfo
-  - name: uname
+pulsar_yaml_config_merged: "{{ pulsar_yaml_config_default | combine(pulsar_yaml_config | default({})) }}"
+
+#pulsar_job_metrics_plugins:
+#  - name: core
+#  - name: cpuinfo
+#    args:
+#      - name: verbose
+#        value: "true"
+#  - name: meminfo
+#  - name: uname
 
 # job_managers.ini contents
 #pulsar_job_managers:

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,10 +1,13 @@
 ---
 galaxy_info:
+  namespace: galaxyproject
+  role_name: pulsar
   author: The Galaxy Project
   description: Install and manage a Pulsar (http://github.com/galaxyproject/pulsar) server.
   company: The Galaxy Project
   license: AFL v3.0
-  min_ansible_version: 1.4
+  min_ansible_version: 2.8
+  github_branch: main
   platforms:
   - name: EL
     versions:

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -35,6 +35,7 @@
         - python3-dev
         - python3-pkg-resources
         - python3-setuptools
+        - python3-virtualenv
 
     - name: "[CentOS 7] Install dependencies"
       yum:

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -17,17 +17,20 @@
         dest: "{{ pulsar_config_dir }}/app.yml"
         mode: 0444
         backup: yes
-      when: pulsar_yaml_config is defined
       notify:
         - "{{ pulsar_restart_handler_name | default('default restart pulsar handler') }}"
 
-    - name: Create Pulsar job manager configuration file
+    - name: Create Pulsar job metrics configuration file
       template:
-        src: "job_managers.ini.j2"
-        dest: "{{ pulsar_job_managers_config }}"
-        mode: 0444
-        backup: yes
-      when: pulsar_job_managers is defined
+        src: "plugin_config.yml.j2"
+        # this uses Python os.path.join which effectively ignores the previous elements in the list if later elements
+        # are absolute paths, so this works regardless of whether pulsar_yaml_config_merged.job_metrics_config_file is
+        # relative or absolute
+        dest: "{{ (pulsar_config_dir, pulsar_yaml_config_merged.job_metrics_config_file) | path_join }}"
+        mode: "0644"
+      vars:
+        __pulsar_plugin_config: "{{ pulsar_job_metrics_plugins }}"
+      when: pulsar_job_metrics_plugins is defined
       notify:
         - "{{ pulsar_restart_handler_name | default('default restart pulsar handler') }}"
 
@@ -37,11 +40,9 @@
         dest: "{{ pulsar_config_dir }}/{{ item }}"
         mode: 0444
         backup: yes
-      with_items:
+      loop:
         - server.ini
         - local_env.sh
-        - job_metrics_conf.xml
-        - dependency_resolvers_conf.xml
       notify:
         - "{{ pulsar_restart_handler_name | default('default restart pulsar handler') }}"
 

--- a/templates/app.yml.j2
+++ b/templates/app.yml.j2
@@ -1,3 +1,3 @@
 ---
 
-{{ pulsar_yaml_config | to_nice_yaml }}
+{{ pulsar_yaml_config_merged | to_nice_yaml }}

--- a/templates/dependency_resolvers_conf.xml.j2
+++ b/templates/dependency_resolvers_conf.xml.j2
@@ -1,9 +1,0 @@
-<?xml version="1.0"?>
-<!--
-    This file is maintained by Ansible - CHANGES WILL BE OVERWRITTEN
--->
-<dependency_resolvers>
-{% for resolver in pulsar_dependency_resolvers %}
-    <{{ resolver.name }}{% for arg in resolver.args |default([]) %} {{ arg.name }}="{{ arg.value }}"{% endfor %} />
-{% endfor %}
-</dependency_resolvers>

--- a/templates/job_managers.ini.j2
+++ b/templates/job_managers.ini.j2
@@ -1,6 +1,0 @@
-{% for manager in pulsar_job_managers %}
-[manager:{{ manager }}]
-{% for opt in pulsar_job_managers[manager] %}
-{{ opt }} = {{ pulsar_job_managers[manager][opt] }}
-{% endfor %}
-{% endfor %}

--- a/templates/job_metrics_conf.xml.j2
+++ b/templates/job_metrics_conf.xml.j2
@@ -1,9 +1,0 @@
-<?xml version="1.0"?>
-<!--
-    This file is maintained by Ansible - CHANGES WILL BE OVERWRITTEN
--->
-<job_metrics>
-{% for plugin in pulsar_job_metrics_plugins %}
-    <{{ plugin.name }}{% for arg in plugin.args |default([]) %} {{ arg.name }}="{{ arg.value }}"{% endfor %} />
-{% endfor %}
-</job_metrics>

--- a/templates/plugin_config.yml.j2
+++ b/templates/plugin_config.yml.j2
@@ -1,0 +1,16 @@
+---
+##
+## This file is managed by Ansible.  ALL CHANGES WILL BE OVERWRITTEN.
+##
+{% if 'name' in (__pulsar_plugin_config | first).keys() %}
+{# Old style (deprecated) YAML-to-XML structure #}
+{% for plugin in __pulsar_plugin_config %}
+- type: {{ plugin.name }}
+{% for arg in plugin.args | default([]) %}
+  {{ arg.name }}: {{ arg.value }}
+{% endfor %}
+{% endfor %}
+{% else %}
+{# New style Galaxy plugin_config YAML #}
+{{ __pulsar_plugin_config | to_nice_yaml }}
+{% endif %}

--- a/tox.ini
+++ b/tox.ini
@@ -23,6 +23,7 @@ setenv =
     MOLECULE_EPHEMERAL_DIRECTORY={toxinidir}/.tox/{env:image:fedora}-{env:tag:latest}/{envname}
     PY_COLORS=1
     ANSIBLE_FORCE_COLOR=1
+    ANSIBLE_ROLES_PATH=../
 
 commands =
     python --version

--- a/tox.ini
+++ b/tox.ini
@@ -11,8 +11,8 @@ skipsdist = true
 
 [testenv]
 deps =
-    previous: ansible>=2.8, <2.9
-    current: ansible>=2.9
+    previous: ansible>=2.9, <2.10
+    current: ansible>=2.10
     next: git+https://github.com/ansible/ansible.git@devel
     molecule>=3, <4
     molecule-docker


### PR DESCRIPTION
- Drop support for dependency_resolvers_conf.xml, this is easily specified directly in the app configuration under `dependency_resolution.resolvers`.
- Convert `pulsar_job_metrics_plugins` to match the Galaxy plugins_config YAML syntax and write YAML instead of XML. The old syntax is still supported for backward compatibility.
- Update documentation.

xref galaxyproject/galaxy#12105 galaxyproject/pulsar#256