### PR TITLE
Don't create config dir (with different perms) in config tasks when it can optionally be created in the paths tasks.

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -4,14 +4,6 @@
 - name: Static config setup
   block:
 
-    - name: Create Pulsar config dir
-      file:
-        state: directory
-        path: "{{ pulsar_config_dir }}"
-        mode: "0755"
-      notify:
-        - "{{ pulsar_restart_handler_name | default('default restart pulsar handler') }}"
-
     - name: Create Pulsar app configuration file
       template:
         src: app.yml.j2


### PR DESCRIPTION
In my case this would cause the dir to be changed to `0750` and then `0755` in every play. If you don't use the paths tasks you can always precreate this dir as needed for your environment.