### PR TITLE
Make config files writable for filesystems that don't interact well

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -8,7 +8,7 @@
       template:
         src: app.yml.j2
         dest: "{{ pulsar_config_dir }}/app.yml"
-        mode: "0444"
+        mode: "0644"
         backup: yes
       notify:
         - "{{ pulsar_restart_handler_name | default('default restart pulsar handler') }}"
@@ -31,7 +31,7 @@
       template:
         src: "{{ item }}.j2"
         dest: "{{ pulsar_config_dir }}/{{ item }}"
-        mode: 0444
+        mode: "0644"
         backup: yes
       loop:
         - server.ini


### PR DESCRIPTION
e.g. on Lustre, it makes the backup but then to `setxattr()` something on the backup file and fails like so:

```
fatal: [hpc.example.edu]: FAILED! => {"changed": false, "checksum": "2733610619849e848b5c069347bce345155c62b1", "msg": "Could not make backup of /lustre/galaxy/pulsar/config/app.yml to /lustre/galaxy/pulsar/config/app.yml.16274.2021-08-27@09:37:51~: [Errno 13] Permission denied: '/lustre/galaxy/pulsar/config/app.yml.16274.2021-08-27@09:37:51~'"}
```

The only reason these were ever read-only to begin with was as a hint to admins that they were Ansible-controlled.