### PR TITLE
Add listen to default restart handlers

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -4,9 +4,11 @@
   debug:
     msg: "RESTARTER NOT IMPLEMENTED - Please restart pulsar manually. You can define your own handler and enable it with `pulsar_restart_handler_name`"
   when: not pulsar_systemd
+  listen: default restart pulsar handler
 
 - name: default restart pulsar handler
   systemd:
     name: "{{ pulsar_systemd_service_name }}.service"
     state: restarted
   when: pulsar_systemd
+  listen: default restart pulsar handler


### PR DESCRIPTION
The restart handler does not run when we use this role in pulsar playbooks.  Two handlers have the same name, one for pulsar_systemd=true and one for pulsar_systemd=false.  Only one of these handlers executes and it is the one for pulsar_systemd=false.  Adding the extra `listen: default restart pulsar handler` means that both handlers execute.