### PR TITLE
Replace deprecated `MemoryLimit` with `MemoryMax` in systemd template (RHEL >= 8)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 __pycache__
 
 *.swp
+
+# Ansible cache directories
+.ansible/

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,3 @@
 __pycache__
 
 *.swp
-
-# Ansible cache directories
-.ansible/

--- a/templates/pulsar.service.j2
+++ b/templates/pulsar.service.j2
@@ -21,7 +21,11 @@ ExecStart={{ pulsar_venv_dir }}/bin/uwsgi --ini-paste {{ pulsar_config_dir }}/se
 {% for env in pulsar_systemd_environment %}
 Environment={{ env }}
 {% endfor %}
+{% if ansible_os_family | lower == 'redhat' and ansible_distribution_major_version | int >= 8 %}
 MemoryMax={{ pulsar_systemd_memory_limit }}G
+{% else %}
+MemoryLimit={{ pulsar_systemd_memory_limit }}G
+{% endif %}
 Restart=always
 
 MemoryAccounting=yes

--- a/templates/pulsar.service.j2
+++ b/templates/pulsar.service.j2
@@ -21,7 +21,7 @@ ExecStart={{ pulsar_venv_dir }}/bin/uwsgi --ini-paste {{ pulsar_config_dir }}/se
 {% for env in pulsar_systemd_environment %}
 Environment={{ env }}
 {% endfor %}
-MemoryLimit={{ pulsar_systemd_memory_limit }}G
+MemoryMax={{ pulsar_systemd_memory_limit }}G
 Restart=always
 
 MemoryAccounting=yes


### PR DESCRIPTION
systemd has deprecated `MemoryLimit=` in favor of `MemoryMax=`. However, `MemoryMax` uses cgroup v2, while `MemoryLimit` uses cgroup v1. Functionally they're supposed to work the same but the newer setting won't work with RHEL7.

Replace `MemoryLimit` with `MemoryMax` in the Pulsar systemd template for RHEL >= 8, keep `MemoryLimit` for RHEL <= 7.