### PR TITLE
Make user owned dirs 755 and umask 027

### DIFF
--- a/tasks/paths.yml
+++ b/tasks/paths.yml
@@ -56,7 +56,7 @@
         state: directory
         owner: "{{ __pulsar_user_name }}"
         group: "{{ __pulsar_user_group }}"
-        mode: "{{ __pulsar_dir_perms }}"
+        mode: "755"
       with_items: "{{ pulsar_dirs }}"
 
   # TODO: for root squashing it might be useful for this to be separate from other root tasks

--- a/templates/pulsar.service.j2
+++ b/templates/pulsar.service.j2
@@ -5,7 +5,7 @@ After=time-sync.target
 After=syslog.target
 
 [Service]
-UMask=022
+UMask=027
 Type=simple
 User={{ __pulsar_user_name }}
 Group={{ __pulsar_user_group }}


### PR DESCRIPTION
For a pulsar submitting jobs as real user the user running jobs need to be able to `cd` into these directories. I'm not 100% sure about the deps dir, but quite sure for staging and persisted data. If we change the umask to 027 no user will be able to cd into any of the subdirs created with these folders (unless the chown script allows it for the user who really needs to access the data).

